### PR TITLE
modify : 유저 태그 리스트 정렬 및 limit, offset

### DIFF
--- a/branch_tags/views.py
+++ b/branch_tags/views.py
@@ -2,12 +2,16 @@ import json
 
 from django.views import View
 from django.http  import JsonResponse
-
+from django.db.models import Count
 from .models import UserTag
 
 class UserTagListView(View) :
     def get(self, request) :
-        user_tag = UserTag.objects.all()
+        limit  = int(request.GET.get('limit', 15))
+        offset = int(request.GET.get('offset', 0))
+
+        user_tag     = UserTag.objects.annotate(total=Count('usersusertags__user_tag_id')).order_by('-total')[offset:limit]
+
         userTag_list = [{'id' : userTag.id, 'tag_name' : userTag.name} for userTag in user_tag]
 
         return JsonResponse({'result' : userTag_list}, status=200)

--- a/branch_tags/views.py
+++ b/branch_tags/views.py
@@ -10,9 +10,7 @@ class UserTagListView(View) :
         limit  = int(request.GET.get('limit', 15))
         offset = int(request.GET.get('offset', 0))
 
-        user_tag     = UserTag.objects.annotate(total=Count('usersusertags__user_tag_id')).order_by('-total')[offset:limit]
+        user_tag = list(UserTag.objects.annotate(total=Count('usersusertags__user_tag_id')).values('id', 'name', 'total').order_by('-total')[offset:limit])
 
-        userTag_list = [{'id' : userTag.id, 'tag_name' : userTag.name} for userTag in user_tag]
-
-        return JsonResponse({'result' : userTag_list}, status=200)
+        return JsonResponse({'result' : user_tag}, status=200)
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 유저 태그 리스트를 메인페이지에 전달하기 위한 기능

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 유저가 많이 사용하고 있는 태그를 내림차순으로 정리하여 limit : 15로 default값을 줬음
 - 데이터가 10만개 있기때문에 모든 태그를 메인페이지에 보낼수 없기에 방법을 바꿈

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 데이터를 전달할 때 고려해야할 사항을 생각할수 있게되었다.

<br />

## :: 기타 질문 및 특이 사항
